### PR TITLE
Support Drupal core version 11

### DIFF
--- a/modules/osu_library_default_image/osu_library_default_image.info.yml
+++ b/modules/osu_library_default_image/osu_library_default_image.info.yml
@@ -2,7 +2,7 @@ name: OSU Library Default Image
 type: module
 description: Provides a default image for existing sites.
 package: OSU
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - default_content:default_content
   - section_library:section_library

--- a/modules/osu_library_hero/osu_library_hero.info.yml
+++ b/modules/osu_library_hero/osu_library_hero.info.yml
@@ -2,7 +2,7 @@ name: OSU Library Hero
 type: module
 description: Provide Layout Library Item for Hero.
 package: OSU
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - default_content:default_content
   - section_library:section_library

--- a/modules/osu_library_three_column_cards/osu_library_three_column_cards.info.yml
+++ b/modules/osu_library_three_column_cards/osu_library_three_column_cards.info.yml
@@ -2,7 +2,7 @@ name: OSU Library Three Column Cards
 type: module
 description: Provide Layout Library Item for a three column OSU Card blocks with an alternative view mode.
 package: OSU
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - default_content:default_content
   - section_library:section_library

--- a/modules/osu_library_three_column_equal/osu_library_three_column_equal.info.yml
+++ b/modules/osu_library_three_column_equal/osu_library_three_column_equal.info.yml
@@ -2,7 +2,7 @@ name: OSU Library Three Column Equal Size
 type: module
 description: Provide Layout Library Item for a three column simple card with an orange border top.
 package: OSU
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - default_content:default_content
   - section_library:section_library

--- a/modules/osu_library_two_column_25_75/osu_library_two_column_25_75.info.yml
+++ b/modules/osu_library_two_column_25_75/osu_library_two_column_25_75.info.yml
@@ -2,7 +2,7 @@ name: OSU Library Two Column 25 75
 type: module
 description: Provide Layout Library Item for an two column 25/75.
 package: OSU
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - default_content:default_content
   - section_library:section_library

--- a/modules/osu_library_two_column_50_50/osu_library_two_column_50_50.info.yml
+++ b/modules/osu_library_two_column_50_50/osu_library_two_column_50_50.info.yml
@@ -2,7 +2,7 @@ name: OSU Library Two Column 50 50
 type: module
 description: Provide Layout Library Item for an two column 50/50.
 package: OSU
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 dependencies:
   - default_content:default_content
   - section_library:section_library

--- a/osu_default_content.info.yml
+++ b/osu_default_content.info.yml
@@ -2,7 +2,7 @@ name: 'OSU Default Content'
 type: module
 description: 'Default content for OSU distributions'
 package: OSU
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^9 || ^10 || ^11
 version: 1.0.3
 dependencies:
   - default_content:default_content


### PR DESCRIPTION
Extended core_version_requirement to include Drupal core version ^11 across multiple OSU library modules. This ensures compatibility and readiness for users upgrading to Drupal 11.